### PR TITLE
 feat(aigis.service): add AssetsCollector to collect assets by custom rules

### DIFF
--- a/src/app/gameData/aigis/aigis.service.ts
+++ b/src/app/gameData/aigis/aigis.service.ts
@@ -13,27 +13,22 @@ import { Event } from './EventList';
 import { Base64 } from './util'
 
 class AssetsCollector {
-    private roster: Map<Array<string>, Array<(data, url) => void>> = new Map();
+    private roster: Map<(file) => boolean, (data, url) => void> = new Map();
+    // eigenUrl以url作key，{Files=[...file], callbackPool:[...callback]}为元素
     public eigenUrl = {}
-    constructor(){}
-    register(flag:Array<string>, callback:(data, url) => void){
-        this.roster.forEach((v,k)=>{
-            if(flag.every(e=>k.indexOf(e)!=-1)){
-                v.push(callback);
-                return;
-            }
-        })
-        this.roster.set(flag, [callback]);
+    constructor() { }
+    register(filter: (file) => boolean, callback: (data, url) => void) {
+        this.roster.set(filter, callback);
     }
-    checkUrl(label:string, url:string) {
-        this.roster.forEach((funcGroup,key)=>{
-            if(key.every(k=>label.includes(k))) {
-                if(this.eigenUrl.hasOwnProperty(url)) {
-                    Array.prototype.push.apply(this.eigenUrl[url].callbackPool, funcGroup);
+    checkUrl(label: string, url: string) {
+        this.roster.forEach((callback, filter) => {
+            if (filter(label)) {
+                if (this.eigenUrl.hasOwnProperty(url)) {
+                    this.eigenUrl[url].callbackPool.push(callback);
                     this.eigenUrl[url].files.push(label)
                 }
                 else {
-                    this.eigenUrl[url] = {callbackPool:[].concat(funcGroup), files:[label]};
+                    this.eigenUrl[url] = { callbackPool: [].concat(callback), files: [label] };
                 }
             }
         })
@@ -44,7 +39,7 @@ class AssetsCollector {
 export class AigisGameDataService {
     private subscription: Map<string, Array<(data, url) => void>> = new Map();
     private requestSubscription: Map<string, Array<(data, url) => void>> = new Map();
-    private assetsRoster: Map<string,string> = new Map();
+    private assetsRoster: Map<string, string> = new Map();
     private assetsCollector: AssetsCollector = new AssetsCollector();
     constructor(
         private debuggerService: DebuggerService
@@ -73,7 +68,7 @@ export class AigisGameDataService {
                     } else { data = response; }
                     data = Xml2json(data);
                     data = data['DA'] || data;
-                    
+
                     subscription.get(channel).forEach((v) => {
                         v(data, url);
                     })
@@ -81,7 +76,7 @@ export class AigisGameDataService {
             }
         );
 
-        
+
         debuggerService.Subscribe(
             {
                 url: ['://assets.millennium-war.net/'],
@@ -89,37 +84,37 @@ export class AigisGameDataService {
                 request: false
             },
             (url, response) => {
-                if(url.indexOf('/2iofz514jeks1y44k7al2ostm43xj085')!=-1||url.indexOf('/1fp32igvpoxnb521p9dqypak5cal0xv0')!=-1) {
+                if (url.indexOf('/2iofz514jeks1y44k7al2ostm43xj085') != -1 || url.indexOf('/1fp32igvpoxnb521p9dqypak5cal0xv0') != -1) {
                     let allFileList = Decoder.DecodeList(response);
-                    allFileList.forEach((v,k)=>{
+                    allFileList.forEach((v, k) => {
                         // fileList里似乎有个无名key
-                        if(k) {
-                            if(this.subscription.has(k)) {
-                                this.assetsRoster.set(v,k);
+                        if (k) {
+                            if (this.subscription.has(k)) {
+                                this.assetsRoster.set(v, k);
                             }
-                            this.assetsCollector.checkUrl(k,v);
-                        }  
+                            this.assetsCollector.checkUrl(k, v);
+                        }
                     });
                 }
-                else if(this.assetsRoster.has(url)||this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
+                else if (this.assetsRoster.has(url) || this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
                     let buffer = response;
                     if (/^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/.test(buffer)) {
                         buffer = Base64.Decode(buffer);
-                    }                
-                    let data = parseAL(buffer)||buffer;
-                    if(this.assetsRoster.has(url)) {
+                    }
+                    let data = parseAL(buffer) || buffer;
+                    if (this.assetsRoster.has(url)) {
                         let channel = this.assetsRoster.get(url)
                         this.subscription.get(channel).forEach((v) => {
                             v(data, url);
                         })
                     }
-                    if(this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
+                    if (this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
                         let obj = this.assetsCollector.eigenUrl[url]
-                        obj.callbackPool.forEach((v)=>{
-                            v({Files:obj.files,Data:data}, url);
+                        obj.callbackPool.forEach((v) => {
+                            v({ Files: obj.files, Data: data }, url);
                         })
                     }
-                    
+
                 }
 
             }
@@ -127,16 +122,16 @@ export class AigisGameDataService {
     }
     subscribe(channel, callback: (data: object, url: string) => void, request?: boolean) {
         const subscription = request ? this.requestSubscription : this.subscription
-        if(typeof(channel)==='string') {
+        if (typeof (channel) === 'string') {
             if (subscription.has(channel)) {
                 subscription.get(channel).push(callback);
             } else {
                 subscription.set(channel, [callback]);
             }
         }
-        else if (typeof(channel)==='object') {
+        else if (typeof (channel) === 'function') {
             this.assetsCollector.register(channel, callback)
         }
-        
+
     }
 }

--- a/src/app/gameData/aigis/aigis.service.ts
+++ b/src/app/gameData/aigis/aigis.service.ts
@@ -14,8 +14,8 @@ import { Base64 } from './util'
 
 class AssetsCollector {
     private roster: Map<(file) => boolean, (data, url) => void> = new Map();
-    // eigenUrl以url作key，{Files=[...file], callbackPool:[...callback]}为元素
-    public eigenUrl = {}
+    // EigenUrls以url作key，{Files=[...file], callbackPool:[...callback]}为元素
+    public EigenUrls = {}
     constructor() { }
     register(filter: (file) => boolean, callback: (data, url) => void) {
         this.roster.set(filter, callback);
@@ -23,12 +23,12 @@ class AssetsCollector {
     checkUrl(label: string, url: string) {
         this.roster.forEach((callback, filter) => {
             if (filter(label)) {
-                if (this.eigenUrl.hasOwnProperty(url)) {
-                    this.eigenUrl[url].callbackPool.push(callback);
-                    this.eigenUrl[url].files.push(label)
+                if (this.EigenUrls.hasOwnProperty(url)) {
+                    this.EigenUrls[url].callbackPool.push(callback);
+                    this.EigenUrls[url].files.push(label)
                 }
                 else {
-                    this.eigenUrl[url] = { callbackPool: [].concat(callback), files: [label] };
+                    this.EigenUrls[url] = { callbackPool: [].concat(callback), files: [label] };
                 }
             }
         })
@@ -96,7 +96,7 @@ export class AigisGameDataService {
                         }
                     });
                 }
-                else if (this.assetsRoster.has(url) || this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
+                else if (this.assetsRoster.has(url) || this.assetsCollector.EigenUrls.hasOwnProperty(url)) {
                     let buffer = response;
                     if (/^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/.test(buffer)) {
                         buffer = Base64.Decode(buffer);
@@ -108,8 +108,8 @@ export class AigisGameDataService {
                             v(data, url);
                         })
                     }
-                    if (this.assetsCollector.eigenUrl.hasOwnProperty(url)) {
-                        let obj = this.assetsCollector.eigenUrl[url]
+                    if (this.assetsCollector.EigenUrls.hasOwnProperty(url)) {
+                        let obj = this.assetsCollector.EigenUrls[url]
                         obj.callbackPool.forEach((v) => {
                             v({ Files: obj.files, Data: data }, url);
                         })


### PR DESCRIPTION
加入一个AssetsCollector，作用是根据文件名条件订阅assets。
因为有许多零碎且需要的assets会根据使用者的行为变化，例如立绘、地图、对话，etc，不可能预先全部订阅。因此加入一个collector，在订阅时传入一个返回bool值的函数channel将使用assetsCollector订阅。
`pluginHelper.aigisGameDataService.subscribe(`
`    file => file.includes('Map') && file.includes('.aar'),`
`    (data, url) => {})`
获取到文件列表后将对每个文件名检验一次，通过则将对应url加入assetsCollector的EigenUrls，之后再根据url回溯找到callback。不同于按文件名返回的data，此时在插件端收到的data将是{Label:文件名， Data:实际的AL}
FP万岁(๑•̀ㅂ•́)و✧