### PR TITLE
chore(electron-updater): set electron-updater to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "compare-versions": "^3.4.0",
     "electron-config": "^2.0.0",
     "electron-log": "^2.2.17",
-    "electron-updater": "^4.2.0",
+    "electron-updater": "4.2.0",
     "element-angular": "^0.7.6",
     "gifuct-js": "^1.0.0",
     "unzipper": "^0.9.4"


### PR DESCRIPTION
due to electron-updater used a higher version of typescript that angular has not supported.